### PR TITLE
add --removeIdentityPairs option

### DIFF
--- a/docs/ref/lingui-cli.rst
+++ b/docs/ref/lingui-cli.rst
@@ -97,7 +97,7 @@ Prints additional information.
 ``compile``
 -----------
 
-.. lingui-cli:: compile [--strict] [--format <format>] [--verbose]
+.. lingui-cli:: compile [--strict] [--format <format>] [--verbose] [--removeIdentityPairs]
 
 This command compiles message catalogs in :conf:`localeDir` and outputs
 minified Javascript files. Each message is replaced with a function
@@ -116,3 +116,7 @@ Format of message catalogs (see :conf:`format` option).
 .. lingui-cli-option:: --verbose
 
 Prints additional information.
+
+.. lingui-cli-option:: --removeIdentityPairs
+
+Reduces the catalog size by removing the entries that have a translation identical with the translation key.

--- a/packages/cli/src/api/compile.js
+++ b/packages/cli/src/api/compile.js
@@ -92,14 +92,31 @@ export function compile(message: string) {
   )
 }
 
-export function createCompiledCatalog(locale: string, messages: CatalogType) {
+export function createCompiledCatalog(
+  locale: string,
+  messages: CatalogType,
+  options: Object
+) {
   const [language] = locale.split("_")
   const pluralRules = plurals[language]
 
-  const compiledMessages = R.keys(messages).map(key => {
-    const translation = messages[key]
-    return t.objectProperty(t.stringLiteral(key), compile(translation || key))
-  })
+  const compiledMessages = R.keys(messages)
+    .filter(key => {
+      if (!(options && options.removeIdentityPairs)) {
+        return true
+      }
+
+      const compiledTranslation = compile(messages[key] || key)
+
+      return !(
+        t.isStringLiteral(compiledTranslation) &&
+        compiledTranslation.value === key
+      )
+    })
+    .map(key => {
+      const translation = messages[key]
+      return t.objectProperty(t.stringLiteral(key), compile(translation || key))
+    })
 
   const languageData = [
     t.objectProperty(

--- a/packages/cli/src/lingui-compile.js
+++ b/packages/cli/src/lingui-compile.js
@@ -84,7 +84,7 @@ function command(config, format, options) {
       }
     }
 
-    const compiledCatalog = createCompiledCatalog(locale, messages)
+    const compiledCatalog = createCompiledCatalog(locale, messages, options)
     const compiledPath = format.writeCompiled(locale, compiledCatalog)
 
     options.verbose && console.log(chalk.green(`${locale} ⇒ ${compiledPath}`))
@@ -100,6 +100,10 @@ if (require.main === module) {
     .option("--strict", "Disable defaults for missing translations")
     .option("--verbose", "Verbose output")
     .option("--format <format>", "Format of message catalog")
+    .option(
+      "--removeIdentityPairs",
+      "Reduces the catalog size by removing the entries that have a translation identical with the translation key"
+    )
     .on("--help", function() {
       console.log("\n  Examples:\n")
       console.log(


### PR DESCRIPTION
**--removeIdentityPairs** option will strip from the catalogs the key-translation pairs for which the key is identical with with the translation.

This option reduces significantly the size of the catalog for the primary language. In our case thee english catalog went from 28805 bytes to 6783 bytes.

The size of the non-primary catalogs remains the same unfortunately.